### PR TITLE
Add Prepare item panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,8 @@ import PreparePanel from "./components/PreparePanel";
 
 function App() {
   const [modalState, setModalState] = useState(null); // For modal control. Pass in callback/args
-  const [editPanelList, setEditPanelList] = useState(null);
+  const [userGearLists, setUserGearLists] = useState([]);
+  const [preparePanelList, setEditPanelList] = useState(null);
 
   const handleSetModalState = (callback, args) => {
     // Handle passing callback function to allow action on modal
@@ -19,7 +20,7 @@ function App() {
     setModalState({ callback, args });
   };
 
-  const handleSetEditPanelList = (gearList) => {
+  const handleSetPreparePanelList = (gearList) => {
     // Handle setting Prepare Panel
     if (gearList === null) {
       setEditPanelList(null);
@@ -32,8 +33,10 @@ function App() {
     <div className="App">
       <Header />
       <Content
+        userGearLists={userGearLists}
+        setUserGearLists={setUserGearLists}
         handleSetModalState={handleSetModalState}
-        handleSetEditPanelList={handleSetEditPanelList}
+        handleSetPreparePanelList={handleSetPreparePanelList}
       />
 
       {modalState != null && (
@@ -43,10 +46,12 @@ function App() {
         />
       )}
 
-      {editPanelList !== null && (
+      {preparePanelList !== null && (
         <PreparePanel
-          editingList={editPanelList}
-          handleSetEditPanelList={handleSetEditPanelList}
+          preparingList={preparePanelList}
+          handleSetPreparePanelList={handleSetPreparePanelList}
+          userGearLists={userGearLists}
+          setUserGearLists={setUserGearLists}
         />
       )}
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -2,9 +2,11 @@ import { useState } from "react";
 import Header from "./components/Header";
 import Content from "./components/Content";
 import ModalWrapper from "./components/ModalWrapper";
+import PreparePanel from "./components/PreparePanel";
 
 function App() {
   const [modalState, setModalState] = useState(null); // For modal control. Pass in callback/args
+  const [editPanelList, setEditPanelList] = useState(null);
 
   const handleSetModalState = (callback, args) => {
     // Handle passing callback function to allow action on modal
@@ -17,15 +19,34 @@ function App() {
     setModalState({ callback, args });
   };
 
+  const handleSetEditPanelList = (gearList) => {
+    // Handle setting Prepare Panel
+    if (gearList === null) {
+      setEditPanelList(null);
+      return;
+    }
+    setEditPanelList(gearList);
+  };
+
   return (
     <div className="App">
       <Header />
-      <Content handleSetModalState={handleSetModalState} />
+      <Content
+        handleSetModalState={handleSetModalState}
+        handleSetEditPanelList={handleSetEditPanelList}
+      />
 
       {modalState != null && (
         <ModalWrapper
           modalState={modalState}
           handleSetModalState={handleSetModalState}
+        />
+      )}
+
+      {editPanelList !== null && (
+        <PreparePanel
+          editingList={editPanelList}
+          handleSetEditPanelList={handleSetEditPanelList}
         />
       )}
     </div>

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -1,13 +1,19 @@
-import style from "./Content.module.css"
+import style from "./Content.module.css";
 import NavPanel from "./NavPanel";
 import CreateGearList from "./GearList";
 
-export default function Content({ handleSetModalState }) {
+export default function Content({
+  handleSetModalState, // For Delete List modal
+  handleSetEditPanelList, // For Prepare side panel
+}) {
   return (
     <div className={style.container}>
       <NavPanel />
       <div className={style["main-content"]}>
-        <CreateGearList handleSetModalState={handleSetModalState} />
+        <CreateGearList
+          handleSetModalState={handleSetModalState}
+          handleSetEditPanelList={handleSetEditPanelList}
+        />
       </div>
     </div>
   );

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -1,18 +1,22 @@
 import style from "./Content.module.css";
 import NavPanel from "./NavPanel";
-import CreateGearList from "./GearList";
+import GearList from "./GearList";
 
 export default function Content({
+  userGearLists, // Existing gear lists
+  setUserGearLists, // Set existing gear lists
   handleSetModalState, // For Delete List modal
-  handleSetEditPanelList, // For Prepare side panel
+  handleSetPreparePanelList, // For Prepare side panel
 }) {
   return (
     <div className={style.container}>
       <NavPanel />
       <div className={style["main-content"]}>
-        <CreateGearList
+        <GearList
+          userGearLists={userGearLists}
+          setUserGearLists={setUserGearLists}
           handleSetModalState={handleSetModalState}
-          handleSetEditPanelList={handleSetEditPanelList}
+          handleSetPreparePanelList={handleSetPreparePanelList}
         />
       </div>
     </div>

--- a/src/components/GearList.js
+++ b/src/components/GearList.js
@@ -4,13 +4,14 @@ import GearListTemplate from "./GearListTemplate";
 import CreateGearListDetails from "./CreateGearListDetails";
 import CONSTANTS from "../constants"
 
-export default function CreateGearList({
+export default function GearList({
+  userGearLists, // Existing gear lists
+  setUserGearLists, // Set existing gear lists
   handleSetModalState, // For Delete List
-  handleSetEditPanelList, // For Prepare side panel
+  handleSetPreparePanelList, // For Prepare side panel
 }) {
 	const [newGearList, setNewGearList] = useState([]);
 	const [newGearStage, setNewGearStage] = useState(CONSTANTS.gearListState.LIST);
-	const [userGearLists, setUserGearLists] = useState([]);
 
 	return (
 		<>
@@ -22,7 +23,7 @@ export default function CreateGearList({
 					setUserGearLists={setUserGearLists}
 					setNewGearList={setNewGearList}
 					handleSetModalState={handleSetModalState}
-					handleSetEditPanelList={handleSetEditPanelList}
+					handleSetPreparePanelList={handleSetPreparePanelList}
 				/>
 			}
 			{

--- a/src/components/GearList.js
+++ b/src/components/GearList.js
@@ -4,7 +4,10 @@ import GearListTemplate from "./GearListTemplate";
 import CreateGearListDetails from "./CreateGearListDetails";
 import CONSTANTS from "../constants"
 
-export default function CreateGearList ({ handleSetModalState }) {
+export default function CreateGearList({
+  handleSetModalState, // For Delete List
+  handleSetEditPanelList, // For Prepare side panel
+}) {
 	const [newGearList, setNewGearList] = useState([]);
 	const [newGearStage, setNewGearStage] = useState(CONSTANTS.gearListState.LIST);
 	const [userGearLists, setUserGearLists] = useState([]);
@@ -19,6 +22,7 @@ export default function CreateGearList ({ handleSetModalState }) {
 					setUserGearLists={setUserGearLists}
 					setNewGearList={setNewGearList}
 					handleSetModalState={handleSetModalState}
+					handleSetEditPanelList={handleSetEditPanelList}
 				/>
 			}
 			{

--- a/src/components/GearListView.js
+++ b/src/components/GearListView.js
@@ -13,7 +13,7 @@ export default function GearListView({
   setUserGearLists,
   setNewGearList,
   handleSetModalState, // for popup modal control
-  handleSetEditPanelList, // For side panel
+  handleSetPreparePanelList, // For side panel
 }) {
   const [visibleDropdownId, setVisibleDropdownId] = useState(null);
   const dropdownRef = useRef(null);
@@ -120,7 +120,7 @@ export default function GearListView({
         <>
           <GearListTable
             gearLists={userGearLists}
-            handleClickListName={handleSetEditPanelList}
+            handleClickListName={handleSetPreparePanelList}
             handleClickEdit={handleEditList}
             handleClickDupldate={handleDuplicatelist}
             handleClickDelete={handleClickDelete}

--- a/src/components/GearListView.js
+++ b/src/components/GearListView.js
@@ -13,6 +13,7 @@ export default function GearListView({
   setUserGearLists,
   setNewGearList,
   handleSetModalState, // for popup modal control
+  handleSetEditPanelList, // For side panel
 }) {
   const [visibleDropdownId, setVisibleDropdownId] = useState(null);
   const dropdownRef = useRef(null);
@@ -117,9 +118,9 @@ export default function GearListView({
 
       {userGearLists.filter((gearList) => !gearList.image).length !== 0 ? (
         <>
-
           <GearListTable
             gearLists={userGearLists}
+            handleClickListName={handleSetEditPanelList}
             handleClickEdit={handleEditList}
             handleClickDupldate={handleDuplicatelist}
             handleClickDelete={handleClickDelete}

--- a/src/components/PreparePanel.js
+++ b/src/components/PreparePanel.js
@@ -1,0 +1,95 @@
+import CONSTANTS from "../constants";
+import Button, {
+  BUTTON_TYPES,
+  ICON_POSITION,
+  ICON_TYPES,
+} from "./atomic/button/Button";
+import Checkbox from "./atomic/Checkbox";
+import style from "./PreparePanel.module.css";
+
+export default function PreparePanel({ editingList, handleSetEditPanelList }) {
+  async function unprepareItem(itemId) {
+    await fetch(`${CONSTANTS.BACKEND_ROOT_URL}/gear-lists/items/${itemId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        Prepared: false,
+      }),
+    });
+
+    // update state
+    const updatedItems = editingList.items.map((item) =>
+      item.id === itemId ? { ...item, prepared: false } : item,
+    );
+    handleSetEditPanelList({ ...editingList, items: updatedItems });
+  }
+
+  async function prepareItem(itemId) {
+    await fetch(`${CONSTANTS.BACKEND_ROOT_URL}/gear-lists/items/${itemId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        Prepared: true,
+      }),
+    });
+
+    // update state
+    const updatedItems = editingList.items.map((item) =>
+      item.id === itemId ? { ...item, prepared: true } : item,
+    );
+    handleSetEditPanelList({ ...editingList, items: updatedItems });
+  }
+
+  return (
+    <div className={style["full-screen-cover"]}>
+      <div className={style["panel"]}>
+        <div className={style["header"]}>
+          <div className={style["title"]}>
+            <div className={style["title-text"]}>{editingList.listName}</div>
+            <Button
+              iconPosition={ICON_POSITION.ICON_ONLY}
+              iconType={ICON_TYPES.CROSS}
+              buttonType={BUTTON_TYPES.TERTIARY}
+              callBack={() => handleSetEditPanelList(null)}
+            />
+          </div>
+          <div className={style["subtitle"]}>
+            Total: <b>{editingList.items.length}</b> items
+          </div>
+        </div>
+        <table className={style["table"]}>
+          <thead className={style["thead"]}>
+            <tr className={style["tr-head"]}>
+              <th className={style["th-empty"]} />
+              <th className={style["th-text"]}>
+                <div className={style["divider"]} />
+                Item
+              </th>
+              <th className={style["th-text"]}>
+                <div className={style["divider"]} />
+                Note
+              </th>
+            </tr>
+          </thead>
+          <tbody className={style["tbody"]}>
+            {editingList.items.map((item) => (
+              <tr key={item.id} className={style["tr"]}>
+                <td className={style["td-checkbox"]}>
+                  <Checkbox
+                    checked={item.prepared}
+                    handleCheck={() => prepareItem(item.id)}
+                    handleUnCheck={() => unprepareItem(item.id)}
+                  />
+                </td>
+                <td className={style["td-text"]}>{item.name}</td>
+                <td className={style["td-text"]}>
+                  {item.note ? item.note : "--"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PreparePanel.js
+++ b/src/components/PreparePanel.js
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import CONSTANTS from "../constants";
 import Button, {
   BUTTON_TYPES,
@@ -5,6 +6,7 @@ import Button, {
   ICON_TYPES,
 } from "./atomic/button/Button";
 import Checkbox from "./atomic/Checkbox";
+import Tooltip from "./atomic/Tooltip";
 import style from "./PreparePanel.module.css";
 
 export default function PreparePanel({
@@ -13,6 +15,8 @@ export default function PreparePanel({
   userGearLists, // Gear Lists on the table view
   setUserGearLists, // Update the table view lists
 }) {
+  const [tootipId, setToolTipId] = useState(null);
+
   const updateUserGearLists = (updatedPreparingList) => {
     // Update Gear Lists table after check/uncheck
     const updatedLists = userGearLists.map((gearList) =>
@@ -81,7 +85,7 @@ export default function PreparePanel({
           </div>
         </div>
         <table className={style["table"]}>
-          <thead className={style["thead"]}>
+          <thead>
             <tr className={style["tr-head"]}>
               <th className={style["th-empty"]} />
               <th className={style["th-text"]}>
@@ -94,7 +98,7 @@ export default function PreparePanel({
               </th>
             </tr>
           </thead>
-          <tbody className={style["tbody"]}>
+          <tbody>
             {preparingList.items.map((item) => (
               <tr key={item.id} className={style["tr"]}>
                 <td className={style["td-checkbox"]}>
@@ -104,9 +108,18 @@ export default function PreparePanel({
                     handleUnCheck={() => unprepareItem(item.id)}
                   />
                 </td>
-                <td className={style["td-text"]}>{item.name}</td>
-                <td className={style["td-text"]}>
-                  {item.note ? item.note : "--"}
+                <td className={style["td-regular"]}>{item.name}</td>
+                <td
+                  className={style["td-regular"]}
+                  onMouseEnter={() => setToolTipId(item.id)}
+                  onMouseLeave={() => setToolTipId(null)}
+                >
+                  <div className={style["td-text"]}>
+                    {item.note ? item.note : "--"}
+                  </div>
+                  {tootipId === item.id && (
+                    <Tooltip promptText={item.note ? item.note : "--"} />
+                  )}
                 </td>
               </tr>
             ))}

--- a/src/components/PreparePanel.js
+++ b/src/components/PreparePanel.js
@@ -67,6 +67,14 @@ export default function PreparePanel({
     updateUserGearLists(updatedPreparingList);
   }
 
+  const handleMouseEnterNote = (itemId, element) => {
+    if (element.scrollWidth > element.clientWidth) setToolTipId(itemId);
+  };
+
+  const handleMouseLeaveNote = () => {
+    setToolTipId(null);
+  };
+
   return (
     <div className={style["full-screen-cover"]}>
       <div className={style["panel"]}>
@@ -109,12 +117,14 @@ export default function PreparePanel({
                   />
                 </td>
                 <td className={style["td-regular"]}>{item.name}</td>
-                <td
-                  className={style["td-regular"]}
-                  onMouseEnter={() => setToolTipId(item.id)}
-                  onMouseLeave={() => setToolTipId(null)}
-                >
-                  <div className={style["td-text"]}>
+                <td className={style["td-regular"]}>
+                  <div
+                    className={style["td-text"]}
+                    onMouseEnter={(event) =>
+                      handleMouseEnterNote(item.id, event.currentTarget)
+                    }
+                    onMouseLeave={() => handleMouseLeaveNote()}
+                  >
                     {item.note ? item.note : "--"}
                   </div>
                   {tootipId === item.id && (

--- a/src/components/PreparePanel.js
+++ b/src/components/PreparePanel.js
@@ -7,7 +7,20 @@ import Button, {
 import Checkbox from "./atomic/Checkbox";
 import style from "./PreparePanel.module.css";
 
-export default function PreparePanel({ editingList, handleSetEditPanelList }) {
+export default function PreparePanel({
+  preparingList, // Current preparing list
+  handleSetPreparePanelList, // Set current preparing list
+  userGearLists, // Gear Lists on the table view
+  setUserGearLists, // Update the table view lists
+}) {
+  const updateUserGearLists = (updatedPreparingList) => {
+    // Update Gear Lists table after check/uncheck
+    const updatedLists = userGearLists.map((gearList) =>
+      gearList.id === preparingList.id ? updatedPreparingList : gearList,
+    );
+    setUserGearLists(updatedLists);
+  };
+
   async function unprepareItem(itemId) {
     await fetch(`${CONSTANTS.BACKEND_ROOT_URL}/gear-lists/items/${itemId}`, {
       method: "PUT",
@@ -18,10 +31,15 @@ export default function PreparePanel({ editingList, handleSetEditPanelList }) {
     });
 
     // update state
-    const updatedItems = editingList.items.map((item) =>
+    const updatedItems = preparingList.items.map((item) =>
       item.id === itemId ? { ...item, prepared: false } : item,
     );
-    handleSetEditPanelList({ ...editingList, items: updatedItems });
+
+    const updatedPreparingList = { ...preparingList, items: updatedItems };
+    handleSetPreparePanelList(updatedPreparingList);
+
+    // Update Gear Lists table
+    updateUserGearLists(updatedPreparingList);
   }
 
   async function prepareItem(itemId) {
@@ -34,10 +52,15 @@ export default function PreparePanel({ editingList, handleSetEditPanelList }) {
     });
 
     // update state
-    const updatedItems = editingList.items.map((item) =>
+    const updatedItems = preparingList.items.map((item) =>
       item.id === itemId ? { ...item, prepared: true } : item,
     );
-    handleSetEditPanelList({ ...editingList, items: updatedItems });
+
+    const updatedPreparingList = { ...preparingList, items: updatedItems };
+    handleSetPreparePanelList(updatedPreparingList);
+
+    // Update Gear Lists table
+    updateUserGearLists(updatedPreparingList);
   }
 
   return (
@@ -45,16 +68,16 @@ export default function PreparePanel({ editingList, handleSetEditPanelList }) {
       <div className={style["panel"]}>
         <div className={style["header"]}>
           <div className={style["title"]}>
-            <div className={style["title-text"]}>{editingList.listName}</div>
+            <div className={style["title-text"]}>{preparingList.listName}</div>
             <Button
               iconPosition={ICON_POSITION.ICON_ONLY}
               iconType={ICON_TYPES.CROSS}
               buttonType={BUTTON_TYPES.TERTIARY}
-              callBack={() => handleSetEditPanelList(null)}
+              callBack={() => handleSetPreparePanelList(null)}
             />
           </div>
           <div className={style["subtitle"]}>
-            Total: <b>{editingList.items.length}</b> items
+            Total: <b>{preparingList.items.length}</b> items
           </div>
         </div>
         <table className={style["table"]}>
@@ -72,7 +95,7 @@ export default function PreparePanel({ editingList, handleSetEditPanelList }) {
             </tr>
           </thead>
           <tbody className={style["tbody"]}>
-            {editingList.items.map((item) => (
+            {preparingList.items.map((item) => (
               <tr key={item.id} className={style["tr"]}>
                 <td className={style["td-checkbox"]}>
                   <Checkbox

--- a/src/components/PreparePanel.module.css
+++ b/src/components/PreparePanel.module.css
@@ -40,7 +40,6 @@
   color: var(--Greyscale-Text-Title, #1F1F1F);
 
   /* H4 / Bold */
-  font-family: Inter;
   font-size: 1.5rem;
   font-style: normal;
   font-weight: 700;
@@ -59,39 +58,26 @@
 }
 
 .table {
-  display: flex;
-  flex-direction: column;
-  flex: 1 0;
+  table-layout: fixed;
+  width: 100%;
   text-align: left;
-}
-
-.thead {
-  display: flex;
-}
-
-.tr-head {
-  display: flex;
-  flex: 1 0 0;
-
-  border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
-  background: var(--LightTeal-Surface-Sutble, #FAFDFE);
-}
-
-.tbody {
-  display: flex;
-  flex-direction: column;
 }
 
 .th-empty {
   padding: 1rem;
   width: 0.875rem;
   height: 1.3125rem;
+
+  border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
+  background: var(--LightTeal-Surface-Sutble, #FAFDFE);  
 }
 
 .th-text {
   position: relative;
   padding: 1rem;
-  flex: 1 0 0;
+
+  border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
+  background: var(--LightTeal-Surface-Sutble, #FAFDFE);
 }
 
 .divider {
@@ -104,25 +90,21 @@
   background-color: #EBEBEB;
 }
 
-.tr {
-  display: flex;
-  align-items: center;
+.td-checkbox {
+  padding: 1rem;
+  width: 0.875rem;
+  height: 1.5rem;
 
   border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
 }
 
-.td-checkbox {
-  display: flex;
-  align-items: center;
+.td-regular {
   padding: 1rem;
-  width: 0.875rem;
-  height: 1.5rem;
+
+  border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
 }
 
 .td-text {
-  flex: 1 0 0;
-  padding: 1rem;
-  
   /* For text overflow */
   overflow:hidden;
   text-overflow: ellipsis;

--- a/src/components/PreparePanel.module.css
+++ b/src/components/PreparePanel.module.css
@@ -59,6 +59,8 @@
 }
 
 .table {
+  display: flex;
+  flex-direction: column;
   flex: 1 0;
   text-align: left;
 }
@@ -120,4 +122,9 @@
 .td-text {
   flex: 1 0 0;
   padding: 1rem;
+  
+  /* For text overflow */
+  overflow:hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/components/PreparePanel.module.css
+++ b/src/components/PreparePanel.module.css
@@ -1,0 +1,123 @@
+.full-screen-cover {
+  display: flex;
+  justify-content: right;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 32.5rem;
+  height: 100%;
+  padding: 2rem 1.5rem;
+
+  border-radius: 0.75rem 0rem 0rem 0.75rem;
+  background-color: #FFF;
+  box-shadow: 0px 16px 32px -4px rgba(58, 52, 69, 0.10), 0px 2px 4px 0px rgba(58, 52, 69, 0.04);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+}
+
+.title-text {
+  color: var(--Greyscale-Text-Title, #1F1F1F);
+
+  /* H4 / Bold */
+  font-family: Inter;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 150%; /* 2.25rem */  
+}
+
+.subtitle {
+  color: var(--Greyscale-Text-Subtitle, #787878);
+
+  /* Body/Regular */
+  font-family: Inter;
+  font-size: 0.875rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%; /* 1.3125rem */
+}
+
+.table {
+  flex: 1 0;
+  text-align: left;
+}
+
+.thead {
+  display: flex;
+}
+
+.tr-head {
+  display: flex;
+  flex: 1 0 0;
+
+  border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
+  background: var(--LightTeal-Surface-Sutble, #FAFDFE);
+}
+
+.tbody {
+  display: flex;
+  flex-direction: column;
+}
+
+.th-empty {
+  padding: 1rem;
+  width: 0.875rem;
+  height: 1.3125rem;
+}
+
+.th-text {
+  position: relative;
+  padding: 1rem;
+  flex: 1 0 0;
+}
+
+.divider {
+  position: absolute;
+  width: 0.0625rem;
+  height: 1.375rem;
+  top: 1rem;
+  bottom: 1rem;
+  left: 0;
+  background-color: #EBEBEB;
+}
+
+.tr {
+  display: flex;
+  align-items: center;
+
+  border-bottom: 1px solid var(--Greyscale-Border-Subtle, #EBEBEB);
+}
+
+.td-checkbox {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  width: 0.875rem;
+  height: 1.5rem;
+}
+
+.td-text {
+  flex: 1 0 0;
+  padding: 1rem;
+}

--- a/src/components/atomic/Checkbox.js
+++ b/src/components/atomic/Checkbox.js
@@ -1,0 +1,31 @@
+import style from "./Checkbox.module.css";
+
+export default function Checkbox({
+  checked, // variable for defining if the checkbox is checked
+  handleCheck, // handle check a checkbox (uncheck -> check)
+  handleUnCheck, // handle uncheck a checkbox (check -> uncheck)
+}) {
+  return (
+    <>
+      {checked && (
+        <div className={style["check"]} onClick={() => handleUnCheck()}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+          >
+            <path
+              d="M5.25009 9.43339L2.81759 7.00089L1.98926 7.82339L5.25009 11.0842L12.2501 4.08422L11.4276 3.26172L5.25009 9.43339Z"
+              fill="white"
+            />
+          </svg>
+        </div>
+      )}
+      {!checked && (
+        <div className={style["uncheck"]} onClick={() => handleCheck()} />
+      )}
+    </>
+  );
+}

--- a/src/components/atomic/Checkbox.module.css
+++ b/src/components/atomic/Checkbox.module.css
@@ -1,0 +1,25 @@
+.check {
+  display: flex;
+  width: 0.875rem;
+  height: 0.875rem;
+  aspect-ratio: 1/1;
+  border-radius: 0.125rem;
+  background: var(--Surface-Default, #116A8D);
+}
+
+.check:hover {
+  cursor: pointer;
+}
+
+.uncheck {
+  width: 0.75rem;
+  height: 0.75rem;
+
+  border-radius: 0.125rem;
+  border: 1px solid var(--Greyscale-Border-Default, #ABABAB);
+  background: var(--Color-White, #FFF);
+}
+
+.uncheck:hover {
+  cursor: pointer;
+}

--- a/src/components/atomic/Tooltip.js
+++ b/src/components/atomic/Tooltip.js
@@ -1,0 +1,10 @@
+import style from "./Tooltip.module.css";
+
+export default function Tooltip({ promptText }) {
+  return (
+    <div className={style["wrapper"]}>
+      <div className={style["diamond"]} />
+      <div className={style["text"]}>{promptText}</div>
+    </div>
+  );
+}

--- a/src/components/atomic/Tooltip.module.css
+++ b/src/components/atomic/Tooltip.module.css
@@ -1,0 +1,37 @@
+.wrapper {
+  position: relative;
+  z-index: 2;
+}
+
+.diamond {
+  position: absolute;
+  top: 0;
+  left: 50%;
+
+  height: 0.5rem;
+  width: 0.5rem;
+  transform: rotate(45deg);
+
+  border-radius: 0.125rem 0rem 0rem 0rem;
+  background-color: #1F1F1F;
+
+}
+
+.text {
+  padding: 0.375rem 0.5rem;
+  position: absolute;
+  width: 100%;
+  top: 0.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+
+  border-radius: 0.125rem;
+  background-color: #1F1F1F;
+  color: var(--Color-White, #FFF);
+
+  /* Body/Regular */
+  font-size: 0.875rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%; /* 1.3125rem */
+}

--- a/src/components/layout/GearListTable.js
+++ b/src/components/layout/GearListTable.js
@@ -40,6 +40,7 @@ const calculateProgressPercentage = (items) => {
 
 export default function GearListTable({
   gearLists,
+  handleClickListName, // For Prepare side panel
   handleClickEdit, // Edit button in dropdown
   handleClickDupldate, // Duplicate button in dropdown
   handleClickDelete, // Delete button in dropdown
@@ -138,6 +139,7 @@ export default function GearListTable({
                     <td className={style["td-small"]}></td>
                     <td
                       className={`${style["td-regular"]} ${style["td-name"]}`}
+                      onClick={() => handleClickListName(gearList)}
                     >
                       {gearList.listName}
                     </td>


### PR DESCRIPTION
- Prepare panel shows up when a Gear List Name cell is clicked
- The panel displays all gear items in the list
- The panel allows users to check/uncheck the checkbox to prepare/unprepare a gear item
- If the item note is too long, the overflow text will be wrapped with ellipses.
- Hover the mouse over the ellipses text will display a tooltip to show the full item note.